### PR TITLE
fix: Remove top-level await from next.config.ts for local development

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,10 +1,4 @@
 import type { NextConfig } from "next";
-import { setupDevPlatform } from "@cloudflare/next-on-pages/next-dev";
-
-// 開発環境の場合はCloudflare Dev Platformをセットアップ
-if (process.env.NODE_ENV === "development") {
-  await setupDevPlatform();
-}
 
 const nextConfig: NextConfig = {
   /* config options here */


### PR DESCRIPTION
## 問題
現在のnext.config.tsでtop-level awaitを使用しているため、ローカル開発環境で以下のエラーが発生します：

```
ReferenceError: await is not defined
    at Object.<anonymous> (/path/to/next.config.compiled.js:14:5)
```

これにより `bun dev` でローカル開発サーバーが起動できない状況です。

## 解決策
- `setupDevPlatform` のimportとtop-level await使用を削除
- ローカル開発環境での正常な動作を確保
- Cloudflare Pagesデプロイ時の互換性は維持

## 検証結果
✅ ローカル開発サーバーが正常に起動（localhost:3000）
✅ Cloudflare Pages デプロイ互換性維持
✅ Next.js 15.2.4 + Turbopack での動作確認済み

## 影響範囲
- ローカル開発環境のみ
- Cloudflare Pages本番デプロイには影響なし
- 開発者体験の大幅改善

🤖 Generated with [Claude Code](https://claude.ai/code)